### PR TITLE
remove pointless assignment

### DIFF
--- a/server.go
+++ b/server.go
@@ -398,7 +398,6 @@ func (server *mongoServer) pinger(loop bool) {
 		if loop {
 			time.Sleep(delay)
 		}
-		op := op
 
 		socket, _, err := server.AcquireSocket(server.dialInfo)
 		if err == nil {


### PR DESCRIPTION
The left and right parts of assiginment are equal.
The assiginment is pointless and can be removed.